### PR TITLE
Clarify ambiguous field in row count query

### DIFF
--- a/src/models/his/his_hi.ts
+++ b/src/models/his/his_hi.ts
@@ -337,7 +337,7 @@ export class HisHiModel {
       ;
 
     if (isRowCount) {
-      return sql.countDistinct('vn as row_count').first();
+      return sql.countDistinct('visit.vn as row_count').first(); // fix bug 'vn' in field list is ambiguous
     } else {
       if (start >= 0) {
         sql = sql.offset(start).limit(limit);


### PR DESCRIPTION
Fix bug by specifying 'visit.vn' to avoid ambiguity.